### PR TITLE
✨ feat : 공통 통신 객체 및 에러 객체 정의

### DIFF
--- a/src/main/java/com/nexters/pinataserver/common/dto/request/CustomPageRequest.java
+++ b/src/main/java/com/nexters/pinataserver/common/dto/request/CustomPageRequest.java
@@ -1,0 +1,22 @@
+package com.nexters.pinataserver.common.dto.request;
+
+import org.springframework.data.domain.PageRequest;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class CustomPageRequest {
+
+	private int pageIndex;
+
+	private int size;
+
+	public PageRequest convertToPageRequest() {
+		return PageRequest.of(pageIndex, size);
+	}
+
+}
+

--- a/src/main/java/com/nexters/pinataserver/common/dto/response/ApiResult.java
+++ b/src/main/java/com/nexters/pinataserver/common/dto/response/ApiResult.java
@@ -1,0 +1,5 @@
+package com.nexters.pinataserver.common.dto.response;
+
+public enum ApiResult {
+	SUCCESS, FAIL
+}

--- a/src/main/java/com/nexters/pinataserver/common/dto/response/CommonApiResponse.java
+++ b/src/main/java/com/nexters/pinataserver/common/dto/response/CommonApiResponse.java
@@ -1,0 +1,35 @@
+package com.nexters.pinataserver.common.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.nexters.pinataserver.common.exception.ResponseException;
+
+import lombok.Getter;
+
+@Getter
+public class CommonApiResponse <T> {
+
+	private final ApiResult result;
+
+	private final T data;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+	private final LocalDateTime serverDatetime;
+
+	protected CommonApiResponse(ApiResult result, T data) {
+		this.result = result;
+		this.data = data;
+		this.serverDatetime = LocalDateTime.now();
+	}
+
+	public static <T> CommonApiResponse<T> ok(T response) {
+		return new CommonApiResponse<>(ApiResult.SUCCESS, response);
+	}
+
+	public static CommonApiResponse<ResponseException> error(ResponseException exception) {
+		return new CommonApiResponse<>(ApiResult.FAIL, exception);
+	}
+
+
+}

--- a/src/main/java/com/nexters/pinataserver/common/dto/response/CustomPageResponse.java
+++ b/src/main/java/com/nexters/pinataserver/common/dto/response/CustomPageResponse.java
@@ -1,0 +1,33 @@
+package com.nexters.pinataserver.common.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class CustomPageResponse<T> {
+
+	private Long totalCount;
+
+	private int pageIndex;
+
+	private int pageSize;
+
+	private List<T> list;
+
+	private boolean hasNext;
+
+	protected CustomPageResponse(Page<T> tPage) {
+		this.totalCount = tPage.getTotalElements();
+		this.pageIndex = tPage.getNumber();
+		this.pageSize = tPage.getSize();
+		this.list = tPage.getContent();
+		this.hasNext = tPage.hasNext();
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/ExceptionControllerAdvice.java
@@ -1,6 +1,9 @@
 package com.nexters.pinataserver.common.exception;
 
+import com.nexters.pinataserver.common.dto.response.CommonApiResponse;
 import com.nexters.pinataserver.common.exception.e5xx.FileUploadException;
+import com.nexters.pinataserver.common.exception.e5xx.UnKnownException;
+
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,18 +21,13 @@ public class ExceptionControllerAdvice {
     private final RedisTemplate<String, String> redisTemplate;
 
     @ExceptionHandler(ResponseException.class)
-    public ResponseEntity<ResponseException> processException(HttpServletRequest request, ResponseException response) {
-        return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+    public CommonApiResponse<ResponseException> processException(ResponseException exception) {
+        return CommonApiResponse.error(exception);
     }
 
-    @ExceptionHandler(FileUploadException.class)
-    public ResponseEntity<ResponseException> fileUploadException(Exception exception) {
-        ResponseException responseException = new ResponseException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                exception.getMessage()
-        );
-        return new ResponseEntity<>(responseException, HttpStatus.valueOf(responseException.getStatus()));
+    @ExceptionHandler(Exception.class)
+    public CommonApiResponse<ResponseException> handleException(Exception exception) {
+        return CommonApiResponse.error(UnKnownException.UNKNOWN.getResponseException());
     }
 
 }

--- a/src/main/java/com/nexters/pinataserver/common/exception/ResponseDefinition.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/ResponseDefinition.java
@@ -8,4 +8,5 @@ public interface ResponseDefinition extends Supplier<ResponseException> {
 	default ResponseException get() {
 		return getResponseException().clone();
 	}
+
 }

--- a/src/main/java/com/nexters/pinataserver/common/exception/ResponseException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/ResponseException.java
@@ -13,7 +13,7 @@ public class ResponseException extends Exception {
 	private int status;
 
 	@EqualsAndHashCode.Include
-	private Integer code;
+	private String code;
 
 	@EqualsAndHashCode.Include
 	private String message;
@@ -24,7 +24,7 @@ public class ResponseException extends Exception {
 		this.message = responseException.message;
 	}
 
-	public ResponseException(HttpStatus status, Integer code, String message) {
+	public ResponseException(HttpStatus status, String code, String message) {
 		this.status = status.value();
 		this.code = code;
 		this.message = message;
@@ -34,4 +34,5 @@ public class ResponseException extends Exception {
 	protected ResponseException clone() {
 		return new ResponseException(this);
 	}
+
 }

--- a/src/main/java/com/nexters/pinataserver/common/exception/e5xx/FileUploadException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e5xx/FileUploadException.java
@@ -1,16 +1,23 @@
 package com.nexters.pinataserver.common.exception.e5xx;
 
-public class FileUploadException extends RuntimeException {
+import org.springframework.http.HttpStatus;
 
-	public FileUploadException() {
+import com.nexters.pinataserver.common.exception.ResponseDefinition;
+import com.nexters.pinataserver.common.exception.ResponseException;
+
+public enum FileUploadException implements ResponseDefinition {
+
+	IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "ERR5001", "이미지 업로드에 실패했습니다.");
+
+	private final ResponseException responseException;
+
+	FileUploadException(HttpStatus status, String code, String message) {
+		this.responseException = new ResponseException(status, code, message);
 	}
 
-	public FileUploadException(Throwable t) {
-		super(t);
-	}
-
-	public FileUploadException(String msg, Throwable cause) {
-		super(msg, cause);
+	@Override
+	public ResponseException getResponseException() {
+		return responseException;
 	}
 
 }

--- a/src/main/java/com/nexters/pinataserver/common/exception/e5xx/UnKnownException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e5xx/UnKnownException.java
@@ -1,15 +1,17 @@
-package com.nexters.pinataserver.common.exception.e4xx;
+package com.nexters.pinataserver.common.exception.e5xx;
+
+import org.springframework.http.HttpStatus;
 
 import com.nexters.pinataserver.common.exception.ResponseDefinition;
 import com.nexters.pinataserver.common.exception.ResponseException;
 
-import org.springframework.http.HttpStatus;
-public enum NotFoundException implements ResponseDefinition {
+public enum UnKnownException implements ResponseDefinition {
 
-	USER(HttpStatus.BAD_REQUEST, "ERR0001", "해당 사용자가 존재하지 않습니다.");
+	UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN", "서버 에러로 인해 데이터를 로드 할 수 없습니다.");
+
 	private final ResponseException responseException;
 
-	NotFoundException(HttpStatus status, String code, String message) {
+	UnKnownException(HttpStatus status, String code, String message) {
 		this.responseException = new ResponseException(status, code, message);
 	}
 


### PR DESCRIPTION
## 1. 주요 내용
- 공통 통신 객체를 정의하였습니다.
  - CommonApiResponse.java
  - CustomPageRequest.java
  - CustomPageResponse.java 

- 예외처리를 위한 에러객체와 핸들러를 정의하였습니다.

## 2. 관련 문서 및 이슈
- resolve #7 

## 3. 작업 내역 
- [x] 공통 통신 객체를 정의
- [x] 오프셋 기반 페이징 객체 정의
- [x] 에러객체 및 핸들러 정의

## 4. 참고 사항 
- 예외처리와 에러객체를 정의하면서 기존에 혜린님이 쓰셨던 에러객체와 제가 사용하던 형태를 조합해서 사용하도록 만들어봤습니다.
원래 저희가 쓰기로 했던 기본 Response 데이터 영역에 혜린님이 사용하시던 에러객체를 넣는 방식으로 만들어봤습니다.
이 부분에 대해서 한번 보시고 피드백 주시면 좋을 것 같아요.



