### PR TITLE
✨ feat : 각 도메인 별 EntityClass 정의

### DIFF
--- a/docker/db/initdb.d/init_db.sql
+++ b/docker/db/initdb.d/init_db.sql
@@ -4,7 +4,7 @@ USE db_pinata;
 
 CREATE TABLE tb_event_histories
 (
-    event_history_id  BIGINT       NOT NULL AUTO_INCREMENT,
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
     created_at        DATETIME,
     updated_at        DATETIME,
     use_flag          BIT          NOT NULL,
@@ -15,12 +15,12 @@ CREATE TABLE tb_event_histories
     participant_id    BIGINT       NOT NULL,
     participant_name  VARCHAR(100) NOT NULL,
     title             VARCHAR(500) NOT NULL,
-    PRIMARY KEY (event_history_id)
+    PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
 CREATE TABLE tb_event_items
 (
-    event_item_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
     created_at      DATETIME,
     updated_at      DATETIME,
     use_flag        BIT          NOT NULL,
@@ -29,12 +29,12 @@ CREATE TABLE tb_event_items
     ranking         INTEGER      NOT NULL,
     title           VARCHAR(500) NOT NULL,
     event_id        BIGINT,
-    PRIMARY KEY (event_item_id)
+    PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
 CREATE TABLE tb_events
 (
-    event_id             BIGINT       NOT NULL AUTO_INCREMENT,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
     created_at           DATETIME,
     updated_at           DATETIME,
     use_flag             BIT          NOT NULL,
@@ -50,24 +50,37 @@ CREATE TABLE tb_events
     participant_count    INTEGER      NOT NULL,
     title                VARCHAR(500) NOT NULL,
     type                 VARCHAR(255),
-    PRIMARY KEY (event_id)
+    PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
-CREATE TABLE tb_users
+# CREATE TABLE tb_users
+# (
+#     id           BIGINT       NOT NULL AUTO_INCREMENT,
+#     created_at        DATETIME,
+#     updated_at        DATETIME,
+#     email             VARCHAR(100) NOT NULL,
+#     nickname          VARCHAR(255),
+#     profile_image_url VARCHAR(255),
+#     provider_id       BIGINT       NOT NULL,
+#     state             VARCHAR(255),
+#     PRIMARY KEY (id)
+# ) ENGINE = InnoDB;
+
+CREATE TABLE users
 (
-    user_id           BIGINT       NOT NULL AUTO_INCREMENT,
+    id                BIGINT NOT NULL AUTO_INCREMENT,
     created_at        DATETIME,
     updated_at        DATETIME,
-    email             VARCHAR(100) NOT NULL,
+    email             VARCHAR(255),
     nickname          VARCHAR(255),
-    prifile_image_url VARCHAR(255),
-    provider_id       BIGINT       NOT NULL,
-    state             VARCHAR(255),
-    PRIMARY KEY (user_id)
+    profile_image_url VARCHAR(255),
+    provider_id       BIGINT,
+    state             INTEGER,
+    PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
 ## Set Constraint
 ALTER TABLE tb_event_items
     ADD CONSTRAINT fk_event_item_to_event
         FOREIGN KEY (event_id)
-            REFERENCES tb_events (event_id);
+            REFERENCES tb_events (id);

--- a/docker/db/initdb.d/init_db.sql
+++ b/docker/db/initdb.d/init_db.sql
@@ -1,3 +1,73 @@
 USE db_pinata;
 
 ## Create Tables
+
+CREATE TABLE tb_event_histories
+(
+    event_history_id  BIGINT       NOT NULL AUTO_INCREMENT,
+    created_at        DATETIME,
+    updated_at        DATETIME,
+    use_flag          BIT          NOT NULL,
+    event_id          BIGINT       NOT NULL,
+    event_item_id     BIGINT       NOT NULL,
+    is_hit            BIT          NOT NULL,
+    participant_email VARCHAR(255) NOT NULL,
+    participant_id    BIGINT       NOT NULL,
+    participant_name  VARCHAR(100) NOT NULL,
+    title             VARCHAR(500) NOT NULL,
+    PRIMARY KEY (event_history_id)
+) ENGINE = InnoDB;
+
+CREATE TABLE tb_event_items
+(
+    event_item_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    created_at      DATETIME,
+    updated_at      DATETIME,
+    use_flag        BIT          NOT NULL,
+    image_file_name VARCHAR(100),
+    is_accepted     BIT          NOT NULL,
+    ranking         INTEGER      NOT NULL,
+    title           VARCHAR(500) NOT NULL,
+    event_id        BIGINT,
+    PRIMARY KEY (event_item_id)
+) ENGINE = InnoDB;
+
+CREATE TABLE tb_events
+(
+    event_id             BIGINT       NOT NULL AUTO_INCREMENT,
+    created_at           DATETIME,
+    updated_at           DATETIME,
+    use_flag             BIT          NOT NULL,
+    close_at             DATETIME,
+    code                 VARCHAR(500) NOT NULL,
+    hit_count            INTEGER      NOT NULL,
+    hit_image_file_name  VARCHAR(100),
+    hit_message          VARCHAR(1000),
+    limit_count          INTEGER      NOT NULL,
+    miss_image_file_name VARCHAR(100),
+    miss_message         VARCHAR(1000),
+    open_at              DATETIME,
+    participant_count    INTEGER      NOT NULL,
+    title                VARCHAR(500) NOT NULL,
+    type                 VARCHAR(255),
+    PRIMARY KEY (event_id)
+) ENGINE = InnoDB;
+
+CREATE TABLE tb_users
+(
+    user_id           BIGINT       NOT NULL AUTO_INCREMENT,
+    created_at        DATETIME,
+    updated_at        DATETIME,
+    email             VARCHAR(100) NOT NULL,
+    nickname          VARCHAR(255),
+    prifile_image_url VARCHAR(255),
+    provider_id       BIGINT       NOT NULL,
+    state             VARCHAR(255),
+    PRIMARY KEY (user_id)
+) ENGINE = InnoDB;
+
+## Set Constraint
+ALTER TABLE tb_event_items
+    ADD CONSTRAINT fk_event_item_to_event
+        FOREIGN KEY (event_id)
+            REFERENCES tb_events (event_id);

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./db/conf.d:/etc/mysql/conf.d
       - ./db/initdb.d:/docker-entrypoint-initdb.d
-    env_file: ../.env
+#    env_file: ../.env
     environment:
       TZ: Asia/Seoul
       MYSQL_ROOT_PASSWORD: 1234

--- a/src/main/java/com/nexters/pinataserver/PinataServerApplication.java
+++ b/src/main/java/com/nexters/pinataserver/PinataServerApplication.java
@@ -2,9 +2,7 @@ package com.nexters.pinataserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class PinataServerApplication {
 

--- a/src/main/java/com/nexters/pinataserver/common/domain/AbstractSoftDeletableEntity.java
+++ b/src/main/java/com/nexters/pinataserver/common/domain/AbstractSoftDeletableEntity.java
@@ -1,0 +1,23 @@
+package com.nexters.pinataserver.common.domain;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AbstractSoftDeletableEntity extends AbstractDateTimeEntity{
+
+	@Column(name = "use_flag", nullable = false)
+	private boolean useFlag = true;
+
+	public void changeUseFlag(boolean useFlag) {
+		this.useFlag = useFlag;
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/Event.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/Event.java
@@ -1,0 +1,126 @@
+package com.nexters.pinataserver.event.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Where;
+
+import com.nexters.pinataserver.common.domain.AbstractSoftDeletableEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "tb_events")
+@Where(clause = "use_flag = true")
+public class Event extends AbstractSoftDeletableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "code", length = 500, nullable = false)
+	private String code;
+
+	@Column(name = "title", length = 500, nullable = false)
+	private String title;
+
+	@Column(name = "open_at")
+	private LocalDateTime openAt;
+
+	@Column(name = "close_at")
+	private LocalDateTime closeAt;
+
+	@Enumerated(EnumType.STRING)
+	private EventType type;
+
+	@Column(name = "limit_count", nullable = false)
+	private Integer limitCount;
+
+	@Column(name = "hit_count", nullable = false)
+	private Integer hitCount;
+
+	@Column(name = "participant_count", nullable = false)
+	private Integer participantCount;
+
+	@Column(name = "hit_image_file_name", length = 100)
+	private String hitImageFileName;
+
+	@Column(name = "hit_message", length = 1000)
+	private String hitMessage;
+
+	@Column(name = "miss_image_file_name", length = 100)
+	private String missImageFileName;
+
+	@Column(name = "miss_message", length = 1000)
+	private String missMessage;
+
+	@Builder.Default
+	@OrderBy("ranking ASC")
+	@OneToMany(
+		mappedBy = "event",
+		cascade = CascadeType.ALL,
+		orphanRemoval = true
+	)
+	private List<EventItem> eventItems = new ArrayList<>();
+
+	private Event(
+		Long id,
+		String code,
+		String title,
+		LocalDateTime openAt,
+		LocalDateTime closeAt,
+		EventType type,
+		Integer limitCount,
+		Integer hitCount,
+		Integer participantCount,
+		String hitImageFileName,
+		String hitMessage,
+		String missImageFileName,
+		String missMessage,
+		List<EventItem> eventItems
+	) {
+		this.id = id;
+		this.code = code;
+		this.title = title;
+		this.openAt = openAt;
+		this.closeAt = closeAt;
+		this.type = type;
+		this.limitCount = limitCount;
+		this.hitCount = hitCount;
+		this.participantCount = participantCount;
+		this.hitImageFileName = hitImageFileName;
+		this.hitMessage = hitMessage;
+		this.missImageFileName = missImageFileName;
+		this.missMessage = missMessage;
+
+		if (Objects.nonNull(eventItems) && !eventItems.isEmpty()) {
+			eventItems.forEach(this::addEventItem);
+		}
+	}
+
+	public void addEventItem(EventItem eventItem) {
+		eventItem.changeEvent(this);
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventItem.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventItem.java
@@ -1,0 +1,78 @@
+package com.nexters.pinataserver.event.domain;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Where;
+
+import com.nexters.pinataserver.common.domain.AbstractSoftDeletableEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_event_items")
+@Where(clause = "use_flag = true")
+public class EventItem extends AbstractSoftDeletableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "title", length = 500, nullable = false)
+	private String title;
+
+	@Column(name = "image_file_name", length = 100)
+	private String imageFileName;
+
+	@Column(name = "ranking", nullable = false)
+	private Integer ranking;
+
+	@Column(name = "is_accepted", nullable = false)
+	private boolean isAccepted;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "event_id", foreignKey = @ForeignKey(name = "fk_event_item_to_event"))
+	private Event event;
+
+	@Builder
+	private EventItem(
+		Long id,
+		String title,
+		String imageFileName,
+		Integer ranking,
+		boolean isAccepted,
+		Event event
+	) {
+		this.id = id;
+		this.title = title;
+		this.imageFileName = imageFileName;
+		this.ranking = ranking;
+		this.isAccepted = isAccepted;
+		this.event = event;
+	}
+
+	public void changeEvent(Event event) {
+		if (Objects.nonNull(event)) {
+			event.getEventItems().remove(this);
+			event.getEventItems().add(this);
+		}
+		this.event = event;
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventType.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventType.java
@@ -1,0 +1,5 @@
+package com.nexters.pinataserver.event.domain;
+
+public enum EventType {
+	WAIT, PROCESS, COMPLETE, CANCEL
+}

--- a/src/main/java/com/nexters/pinataserver/event_history/domain/EventHistory.java
+++ b/src/main/java/com/nexters/pinataserver/event_history/domain/EventHistory.java
@@ -1,0 +1,73 @@
+package com.nexters.pinataserver.event_history.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Where;
+
+import com.nexters.pinataserver.common.domain.AbstractSoftDeletableEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_event_histories")
+@Where(clause = "use_flag = true")
+public class EventHistory extends AbstractSoftDeletableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "event_id", nullable = false)
+	private Long eventId;
+
+	@Column(name = "title", length = 500, nullable = false)
+	private String title;
+
+	@Column(name = "participant_id", nullable = false)
+	private Long participantId;
+
+	@Column(name = "participant_email", nullable = false)
+	private String participantEmail;
+
+	@Column(name = "participant_name", length = 100, nullable = false)
+	private String participantName;
+
+	@Column(name = "is_hit", nullable = false)
+	private boolean isHit;
+
+	@Column(name = "event_item_id", nullable = false)
+	private Long eventItemId;
+
+	@Builder
+	private EventHistory(
+		Long id,
+		Long eventId,
+		String title,
+		Long participantId,
+		String participantEmail,
+		String participantName,
+		boolean isHit,
+		Long eventItemId
+	) {
+		this.id = id;
+		this.eventId = eventId;
+		this.title = title;
+		this.participantId = participantId;
+		this.participantEmail = participantEmail;
+		this.participantName = participantName;
+		this.isHit = isHit;
+		this.eventItemId = eventItemId;
+	}
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: 1234
-    url: jdbc:mysql://localhost:3308/db_pinata?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:3308/db_pinata?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&allowPublicKeyRetrieval=true
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
## 1. 주요 내용
- 도메인 별 Entity Class를 정의하였습니다.
- DockerCompose에 DB Scheme 를 정의해두었습니다.

## 2. 관련 문서 및 이슈
- resolve #6 

## 3. 작업 내역 
- [x] 각 도메인 별 Entity Class 정의
- [x] DockerCompose에 스키마 세팅
- [x] User Entity 수정
- [x] SoftDelete를 위한 AbstractEntity 정의

## 4. 참고 사항 
- 아래와 같은 명령어를 터미널에 입력하면 Local DB가 세팅됩니다.
  ``` bash
    cd docker
    docker-compose up -b
  ```
- User Class를 수정했습니다.
일단 제 임의대로 수정했는데...
이상한 점은 피드백 부탁드립니다. 
수정이 필요 없을 경우 이부분만 롤백해서 반영하겠습니다.

- 아직 ValidationCheck 까지는 넣지 않았습니다.
Entity가 몇개 없으니 이부분은 개발 진행하면서 추가하갰습니다.

- 다른 Entity도 SoftDelete 적용을 위해 AbstractClass를 정의했습니다.

