### PR TITLE
Feature/9 이벤트 참여 로직 더미 API 생성

### DIFF
--- a/docker/db/initdb.d/init_db.sql
+++ b/docker/db/initdb.d/init_db.sql
@@ -34,7 +34,7 @@ CREATE TABLE tb_event_items
 
 CREATE TABLE tb_events
 (
-    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
     created_at           DATETIME,
     updated_at           DATETIME,
     use_flag             BIT          NOT NULL,
@@ -50,6 +50,7 @@ CREATE TABLE tb_events
     participant_count    INTEGER      NOT NULL,
     title                VARCHAR(500) NOT NULL,
     type                 VARCHAR(255),
+    status               VARCHAR(255),
     PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 

--- a/src/main/java/com/nexters/pinataserver/event/controller/EventReadController.java
+++ b/src/main/java/com/nexters/pinataserver/event/controller/EventReadController.java
@@ -1,0 +1,72 @@
+package com.nexters.pinataserver.event.controller;
+
+import static com.nexters.pinataserver.event.controller.EventReadController.*;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import com.nexters.pinataserver.common.dto.response.CommonApiResponse;
+import com.nexters.pinataserver.event.domain.EventStatus;
+import com.nexters.pinataserver.event.domain.EventType;
+import com.nexters.pinataserver.event.dto.request.ParticipateEventRequest;
+import com.nexters.pinataserver.event.dto.response.ParticipateEventResponse;
+import com.nexters.pinataserver.event.dto.response.ReadCurrentParticipateEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(BASE_URI)
+public class EventReadController {
+
+	public static final String BASE_URI = "/api/v1/events";
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping(value = "/participate/{eventCode}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public CommonApiResponse<ReadCurrentParticipateEvent> readCurrentParticipateEvent(
+		@PathVariable("eventCode") String eventCode
+	) {
+		LocalDateTime now = LocalDateTime.now();
+		ReadCurrentParticipateEvent response = ReadCurrentParticipateEvent.builder()
+			.code(eventCode)
+			.type(EventType.FCFS)
+			.status(EventStatus.PROCESS)
+			.isPeriod(true)
+			.openAt(now.plusSeconds(20))
+			.closeAt(now.plusHours(1))
+			.hitImageUrl("https://kr.object.ncloudstorage.com/pinata-bucket/images/hit-image.jpeg")
+			.hitMessage("축하합니다~ 남은 넥스터즈 기간도 화이팅~!")
+			.missImageUrl("https://kr.object.ncloudstorage.com/pinata-bucket/images/miss-image.jpeg")
+			.missMessage("메롱~~~~")
+			.title("넥스터즈 21기 깜짝 선물 3분께 드립니다.")
+			.build();
+
+		return CommonApiResponse.<ReadCurrentParticipateEvent>ok(response);
+	}
+
+	@ResponseStatus(HttpStatus.OK)
+	@PostMapping(
+		value = "/participate",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
+	public CommonApiResponse<ParticipateEventResponse> participateEvent(
+		@RequestBody ParticipateEventRequest request
+	) {
+		ParticipateEventResponse response = ParticipateEventResponse.builder()
+			.code(request.getCode())
+			.itemId(1L)
+			.itemTitle("스타벅스 아메리카노 톨 사이즈")
+			.result(true)
+			.resultImageURL("https://kr.object.ncloudstorage.com/pinata-bucket/images/hit-image.jpeg")
+			.resultMessage("당첨되셨습니다. 축하드립니다! 선물 받기 버튼을 눌러 이미지를 저장하세요.")
+			.itemImageUrl("https://kr.object.ncloudstorage.com/pinata-bucket/images/product-image.jpeg")
+			.build();
+
+		return CommonApiResponse.<ParticipateEventResponse>ok(response);
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/Event.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/Event.java
@@ -54,6 +54,10 @@ public class Event extends AbstractSoftDeletableEntity {
 	@Enumerated(EnumType.STRING)
 	private EventType type;
 
+
+	@Enumerated(EnumType.STRING)
+	private EventStatus status;
+
 	@Column(name = "limit_count", nullable = false)
 	private Integer limitCount;
 
@@ -91,6 +95,7 @@ public class Event extends AbstractSoftDeletableEntity {
 		LocalDateTime openAt,
 		LocalDateTime closeAt,
 		EventType type,
+		EventStatus status,
 		Integer limitCount,
 		Integer hitCount,
 		Integer participantCount,
@@ -106,6 +111,7 @@ public class Event extends AbstractSoftDeletableEntity {
 		this.openAt = openAt;
 		this.closeAt = closeAt;
 		this.type = type;
+		this.status = status;
 		this.limitCount = limitCount;
 		this.hitCount = hitCount;
 		this.participantCount = participantCount;

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventStatus.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventStatus.java
@@ -1,0 +1,5 @@
+package com.nexters.pinataserver.event.domain;
+
+public enum EventStatus {
+	WAIT, PROCESS, COMPLETE, CANCEL
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventType.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventType.java
@@ -1,5 +1,5 @@
 package com.nexters.pinataserver.event.domain;
 
 public enum EventType {
-	WAIT, PROCESS, COMPLETE, CANCEL
+	FCFS, RANDOM
 }

--- a/src/main/java/com/nexters/pinataserver/event/dto/request/ParticipateEventRequest.java
+++ b/src/main/java/com/nexters/pinataserver/event/dto/request/ParticipateEventRequest.java
@@ -1,0 +1,13 @@
+package com.nexters.pinataserver.event.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipateEventRequest {
+
+	private String code;
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/dto/response/ParticipateEventResponse.java
+++ b/src/main/java/com/nexters/pinataserver/event/dto/response/ParticipateEventResponse.java
@@ -1,0 +1,42 @@
+package com.nexters.pinataserver.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ParticipateEventResponse {
+
+	private final String code;
+
+	private final boolean result;
+
+	private final String resultMessage;
+
+	private final String resultImageURL;
+
+	private final Long itemId;
+
+	private final String itemTitle;
+
+	private final String itemImageUrl;
+
+	@Builder
+	public ParticipateEventResponse(
+		String code,
+		boolean result,
+		String resultMessage,
+		String resultImageURL,
+		Long itemId,
+		String itemTitle,
+		String itemImageUrl
+	) {
+		this.code = code;
+		this.result = result;
+		this.resultMessage = resultMessage;
+		this.resultImageURL = resultImageURL;
+		this.itemId = itemId;
+		this.itemTitle = itemTitle;
+		this.itemImageUrl = itemImageUrl;
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/dto/response/ReadCurrentParticipateEvent.java
+++ b/src/main/java/com/nexters/pinataserver/event/dto/response/ReadCurrentParticipateEvent.java
@@ -1,0 +1,66 @@
+package com.nexters.pinataserver.event.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.nexters.pinataserver.event.domain.EventStatus;
+import com.nexters.pinataserver.event.domain.EventType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReadCurrentParticipateEvent {
+
+	private final String title;
+
+	private final String code;
+
+	private final EventType type;
+
+	private final EventStatus status;
+
+	private final String hitMessage;
+
+	private final String hitImageUrl;
+
+	private final String missMessage;
+
+	private final String missImageUrl;
+
+	private final boolean isPeriod;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+	private final LocalDateTime openAt;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+	private final LocalDateTime closeAt;
+
+	@Builder
+	public ReadCurrentParticipateEvent(
+		String title,
+		String code,
+		EventType type,
+		EventStatus status,
+		String hitMessage,
+		String hitImageUrl,
+		String missMessage,
+		String missImageUrl,
+		boolean isPeriod,
+		LocalDateTime openAt,
+		LocalDateTime closeAt
+	) {
+		this.title = title;
+		this.code = code;
+		this.type = type;
+		this.status = status;
+		this.hitMessage = hitMessage;
+		this.hitImageUrl = hitImageUrl;
+		this.missMessage = missMessage;
+		this.missImageUrl = missImageUrl;
+		this.isPeriod = isPeriod;
+		this.openAt = openAt;
+		this.closeAt = closeAt;
+	}
+}


### PR DESCRIPTION
## 1. 주요 내용
- EventStatus 필드 추가
- "참여 할 이벤트 정보 조회", "이벤트 참여" 더미 API 생성

## 2. 관련 문서 및 이슈

## 3. 작업 내역 
- [x] EventStatus 필드 추가
- [x] "참여 할 이벤트 정보 조회", "이벤트 참여" 더미 API 생성

## 4. 참고 사항 
이벤트 참여 로직에 필요한 API를 더미데이터를 반환하도록 만들었습니다.
제대로 된 구현은 좀 늦을 것 같아서 일단 프론트 분들이 붙어서 통신만 되게끔 만들었습니다.
이 API들에 대해서는 개발 후 다시 반영하겠습니다. ( 일단 시연 용도로만 만들었습니다. )


