### PR TITLE
✨ feat : 참여 할 이벤트 조회 API 구현

### DIFF
--- a/docker/db/initdb.d/init_db.sql
+++ b/docker/db/initdb.d/init_db.sql
@@ -38,25 +38,26 @@ CREATE TABLE tb_events
     created_at           DATETIME,
     updated_at           DATETIME,
     use_flag             BIT          NOT NULL,
-    close_at             DATETIME,
     code                 VARCHAR(500) NOT NULL,
+    close_at             DATETIME,
+    is_period            BIT,
+    open_at              DATETIME,
     hit_count            INTEGER      NOT NULL,
     hit_image_file_name  VARCHAR(100),
     hit_message          VARCHAR(1000),
     limit_count          INTEGER      NOT NULL,
     miss_image_file_name VARCHAR(100),
     miss_message         VARCHAR(1000),
-    open_at              DATETIME,
     participant_count    INTEGER      NOT NULL,
+    status               VARCHAR(255),
     title                VARCHAR(500) NOT NULL,
     type                 VARCHAR(255),
-    status               VARCHAR(255),
     PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
 CREATE TABLE tb_users
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
     created_at        DATETIME,
     updated_at        DATETIME,
     email             VARCHAR(100) NOT NULL,

--- a/src/main/java/com/nexters/pinataserver/common/exception/e4xx/DuplicatedException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e4xx/DuplicatedException.java
@@ -4,14 +4,14 @@ import org.springframework.http.HttpStatus;
 
 import com.nexters.pinataserver.common.exception.ResponseDefinition;
 import com.nexters.pinataserver.common.exception.ResponseException;
-public enum NotFoundException implements ResponseDefinition {
 
-	USER(HttpStatus.BAD_REQUEST, "ERR0001", "해당 사용자가 존재하지 않습니다."),
-	EVENT(HttpStatus.BAD_REQUEST, "ERR1001", "해당 이벤트가 존재하지 않습니다."),
-	;
+public enum DuplicatedException implements ResponseDefinition {
+
+	EVENT_HISTORY(HttpStatus.BAD_REQUEST, "ERR2003", "이미 참여한 이벤트입니다.");
+
 	private final ResponseException responseException;
 
-	NotFoundException(HttpStatus status, String code, String message) {
+	DuplicatedException(HttpStatus status, String code, String message) {
 		this.responseException = new ResponseException(status, code, message);
 	}
 

--- a/src/main/java/com/nexters/pinataserver/common/exception/e4xx/EventStatusException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e4xx/EventStatusException.java
@@ -4,14 +4,15 @@ import org.springframework.http.HttpStatus;
 
 import com.nexters.pinataserver.common.exception.ResponseDefinition;
 import com.nexters.pinataserver.common.exception.ResponseException;
-public enum NotFoundException implements ResponseDefinition {
 
-	USER(HttpStatus.BAD_REQUEST, "ERR0001", "해당 사용자가 존재하지 않습니다."),
-	EVENT(HttpStatus.BAD_REQUEST, "ERR1001", "해당 이벤트가 존재하지 않습니다."),
+public enum EventStatusException implements ResponseDefinition {
+
+	COMPLETE(HttpStatus.BAD_REQUEST, "ERR1002", "이미 완료된 이벤트입니다."),
+	CANCEL(HttpStatus.BAD_REQUEST, "ERR1003", "해당 이벤트가 취소되었습니다."),
 	;
 	private final ResponseException responseException;
 
-	NotFoundException(HttpStatus status, String code, String message) {
+	EventStatusException(HttpStatus status, String code, String message) {
 		this.responseException = new ResponseException(status, code, message);
 	}
 

--- a/src/main/java/com/nexters/pinataserver/common/exception/e4xx/EventTimeException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e4xx/EventTimeException.java
@@ -4,14 +4,14 @@ import org.springframework.http.HttpStatus;
 
 import com.nexters.pinataserver.common.exception.ResponseDefinition;
 import com.nexters.pinataserver.common.exception.ResponseException;
-public enum NotFoundException implements ResponseDefinition {
 
-	USER(HttpStatus.BAD_REQUEST, "ERR0001", "해당 사용자가 존재하지 않습니다."),
-	EVENT(HttpStatus.BAD_REQUEST, "ERR1001", "해당 이벤트가 존재하지 않습니다."),
-	;
+public enum EventTimeException implements ResponseDefinition {
+
+	TIME_OUT(HttpStatus.BAD_REQUEST, "ERR1002", "이벤트 참여 기간이 아닙니다."),
+	INVALID_INPUT(HttpStatus.BAD_REQUEST, "ERR1003", "이벤트 기간 입력이 잘못되었습니다.");
 	private final ResponseException responseException;
 
-	NotFoundException(HttpStatus status, String code, String message) {
+	EventTimeException(HttpStatus status, String code, String message) {
 		this.responseException = new ResponseException(status, code, message);
 	}
 

--- a/src/main/java/com/nexters/pinataserver/common/util/ImageUtil.java
+++ b/src/main/java/com/nexters/pinataserver/common/util/ImageUtil.java
@@ -1,0 +1,20 @@
+package com.nexters.pinataserver.common.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageUtil {
+
+	@Value("${ncp.bucket_name}")
+	private String bucketPath;
+
+	protected String extractImageFileName(String imageUrl) {
+		return imageUrl.replace(bucketPath, "");
+	}
+
+	public String getFullImageUrl(String imageFileName) {
+		return bucketPath.concat(imageFileName);
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/controller/EventReadController.java
+++ b/src/main/java/com/nexters/pinataserver/event/controller/EventReadController.java
@@ -6,14 +6,22 @@ import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.nexters.pinataserver.common.dto.response.CommonApiResponse;
+import com.nexters.pinataserver.common.security.AuthenticationPrincipal;
 import com.nexters.pinataserver.event.domain.EventStatus;
 import com.nexters.pinataserver.event.domain.EventType;
 import com.nexters.pinataserver.event.dto.request.ParticipateEventRequest;
 import com.nexters.pinataserver.event.dto.response.ParticipateEventResponse;
-import com.nexters.pinataserver.event.dto.response.ReadCurrentParticipateEvent;
+import com.nexters.pinataserver.event.dto.response.ReadCurrentParticipateEventResponse;
+import com.nexters.pinataserver.event.service.EventReadService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,13 +32,17 @@ public class EventReadController {
 
 	public static final String BASE_URI = "/api/v1/events";
 
+	private final EventReadService eventReadService;
+
 	@ResponseStatus(HttpStatus.OK)
 	@GetMapping(value = "/participate/{eventCode}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public CommonApiResponse<ReadCurrentParticipateEvent> readCurrentParticipateEvent(
-		@PathVariable("eventCode") String eventCode
+
+	public CommonApiResponse<ReadCurrentParticipateEventResponse> readCurrentParticipateEvent(
+		@PathVariable("eventCode") String eventCode,
+		@AuthenticationPrincipal Long userId
 	) {
 		LocalDateTime now = LocalDateTime.now();
-		ReadCurrentParticipateEvent response = ReadCurrentParticipateEvent.builder()
+		ReadCurrentParticipateEventResponse response = ReadCurrentParticipateEventResponse.builder()
 			.code(eventCode)
 			.type(EventType.FCFS)
 			.status(EventStatus.PROCESS)
@@ -44,7 +56,9 @@ public class EventReadController {
 			.title("넥스터즈 21기 깜짝 선물 3분께 드립니다.")
 			.build();
 
-		return CommonApiResponse.<ReadCurrentParticipateEvent>ok(response);
+		// ReadCurrentParticipateEventResponse response = eventReadService.getParticipateEvent(userId, eventCode);
+
+		return CommonApiResponse.<ReadCurrentParticipateEventResponse>ok(response);
 	}
 
 	@ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/nexters/pinataserver/event/domain/Event.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/Event.java
@@ -1,12 +1,12 @@
 package com.nexters.pinataserver.event.domain;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -45,15 +45,11 @@ public class Event extends AbstractSoftDeletableEntity {
 	@Column(name = "title", length = 500, nullable = false)
 	private String title;
 
-	@Column(name = "open_at")
-	private LocalDateTime openAt;
-
-	@Column(name = "close_at")
-	private LocalDateTime closeAt;
+	@Embedded
+	private EventDateTime eventDateTime;
 
 	@Enumerated(EnumType.STRING)
 	private EventType type;
-
 
 	@Enumerated(EnumType.STRING)
 	private EventStatus status;
@@ -88,12 +84,11 @@ public class Event extends AbstractSoftDeletableEntity {
 	)
 	private List<EventItem> eventItems = new ArrayList<>();
 
-	private Event(
+	public Event(
 		Long id,
 		String code,
 		String title,
-		LocalDateTime openAt,
-		LocalDateTime closeAt,
+		EventDateTime eventDateTime,
 		EventType type,
 		EventStatus status,
 		Integer limitCount,
@@ -108,8 +103,7 @@ public class Event extends AbstractSoftDeletableEntity {
 		this.id = id;
 		this.code = code;
 		this.title = title;
-		this.openAt = openAt;
-		this.closeAt = closeAt;
+		this.eventDateTime = eventDateTime;
 		this.type = type;
 		this.status = status;
 		this.limitCount = limitCount;

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventDateTime.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventDateTime.java
@@ -1,0 +1,58 @@
+package com.nexters.pinataserver.event.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import com.nexters.pinataserver.common.exception.e4xx.EventTimeException;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class EventDateTime {
+
+	@Column(name = "is_period", nullable = false)
+	private Boolean isPeriod;
+
+	@Column(name = "open_at")
+	private LocalDateTime openAt;
+
+	@Column(name = "close_at")
+	private LocalDateTime closeAt;
+
+	@Builder
+	public EventDateTime(Boolean isPeriod, LocalDateTime openAt, LocalDateTime closeAt) {
+		validate(isPeriod, openAt, closeAt);
+		this.isPeriod = isPeriod;
+		this.openAt = openAt;
+		this.closeAt = closeAt;
+	}
+
+	private void validate(Boolean isPeriod, LocalDateTime openAt, LocalDateTime closeAt) {
+		checkIsPeriod(isPeriod, openAt, closeAt);
+		checkOpenCloseDateTimeValidation(openAt, closeAt);
+	}
+
+	private void checkOpenCloseDateTimeValidation(LocalDateTime openAt, LocalDateTime closeAt) {
+		if (openAt.isAfter(closeAt)) {
+			throw EventTimeException.INVALID_INPUT.get();
+		}
+	}
+
+	private void checkIsPeriod(Boolean isPeriod, LocalDateTime openAt, LocalDateTime closeAt) {
+		if (isPeriod && (Objects.isNull(openAt) || Objects.isNull(closeAt))) {
+			throw EventTimeException.INVALID_INPUT.get();
+		}
+	}
+
+	public boolean isCanNotParticipate(LocalDateTime now) {
+		return now.isAfter(closeAt) || now.isBefore(openAt);
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventRepository.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventRepository.java
@@ -1,0 +1,12 @@
+package com.nexters.pinataserver.event.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+	Optional<Event> findByCode(@Param("code") String eventCode);
+
+}

--- a/src/main/java/com/nexters/pinataserver/event/dto/response/ReadCurrentParticipateEventResponse.java
+++ b/src/main/java/com/nexters/pinataserver/event/dto/response/ReadCurrentParticipateEventResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ReadCurrentParticipateEvent {
+public class ReadCurrentParticipateEventResponse {
 
 	private final String title;
 
@@ -38,7 +38,7 @@ public class ReadCurrentParticipateEvent {
 	private final LocalDateTime closeAt;
 
 	@Builder
-	public ReadCurrentParticipateEvent(
+	public ReadCurrentParticipateEventResponse(
 		String title,
 		String code,
 		EventType type,
@@ -63,4 +63,5 @@ public class ReadCurrentParticipateEvent {
 		this.openAt = openAt;
 		this.closeAt = closeAt;
 	}
+
 }

--- a/src/main/java/com/nexters/pinataserver/event/service/EventReadService.java
+++ b/src/main/java/com/nexters/pinataserver/event/service/EventReadService.java
@@ -1,0 +1,79 @@
+package com.nexters.pinataserver.event.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nexters.pinataserver.common.exception.e4xx.DuplicatedException;
+import com.nexters.pinataserver.common.exception.e4xx.EventStatusException;
+import com.nexters.pinataserver.common.exception.e4xx.EventTimeException;
+import com.nexters.pinataserver.common.exception.e4xx.NotFoundException;
+import com.nexters.pinataserver.common.util.ImageUtil;
+import com.nexters.pinataserver.event.domain.Event;
+import com.nexters.pinataserver.event.domain.EventDateTime;
+import com.nexters.pinataserver.event.domain.EventRepository;
+import com.nexters.pinataserver.event.domain.EventStatus;
+import com.nexters.pinataserver.event.dto.response.ReadCurrentParticipateEventResponse;
+import com.nexters.pinataserver.event_history.domain.EventHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventReadService {
+
+	private final EventRepository eventRepository;
+
+	private final EventHistoryRepository eventHistoryRepository;
+
+	private final ImageUtil imageUtil;
+
+	public ReadCurrentParticipateEventResponse getParticipateEvent(Long participantId, String eventCode) {
+
+		// 이벤트 조회
+		Event foundEvent = eventRepository.findByCode(eventCode)
+			.orElseThrow(NotFoundException.EVENT);
+
+		// 이벤트 참가 대상자 인가??
+		Boolean isAlreadyParticipate = eventHistoryRepository.existsByParticipantId(participantId);
+		if (isAlreadyParticipate) {
+			throw DuplicatedException.EVENT_HISTORY.get();
+		}
+
+		// 기간이 지나지는 않았나??
+		EventDateTime eventDateTime = foundEvent.getEventDateTime();
+		LocalDateTime now = LocalDateTime.now();
+		if (eventDateTime.isCanNotParticipate(now)) {
+			throw EventTimeException.TIME_OUT.get();
+		}
+
+		// 이벤트 상태가 참가 가능한 이벤트 인가??
+		if (foundEvent.getStatus() == EventStatus.COMPLETE) {
+			throw EventStatusException.COMPLETE.get();
+		}
+		if (foundEvent.getStatus() == EventStatus.CANCEL) {
+			throw EventStatusException.CANCEL.get();
+		}
+
+		return ReadCurrentParticipateEventResponse.builder()
+			.title(foundEvent.getTitle())
+			.code(foundEvent.getCode())
+			.status(foundEvent.getStatus())
+			.type(foundEvent.getType())
+			.hitMessage(foundEvent.getHitMessage())
+			.hitImageUrl(
+				imageUtil.getFullImageUrl(foundEvent.getHitImageFileName())
+			)
+			.missMessage(foundEvent.getMissMessage())
+			.missImageUrl(
+				imageUtil.getFullImageUrl(foundEvent.getMissImageFileName())
+			)
+			.isPeriod(foundEvent.getEventDateTime().getIsPeriod())
+			.openAt(foundEvent.getEventDateTime().getOpenAt())
+			.closeAt(foundEvent.getEventDateTime().getCloseAt())
+			.build();
+	}
+
+}

--- a/src/main/java/com/nexters/pinataserver/event_history/domain/EventHistoryRepository.java
+++ b/src/main/java/com/nexters/pinataserver/event_history/domain/EventHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.nexters.pinataserver.event_history.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface EventHistoryRepository extends JpaRepository<EventHistory, Long> {
+
+	Boolean existsByParticipantId(@Param("participantId") Long participantId);
+
+}

--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -1,0 +1,7 @@
+ncp:
+  #  end_point: ${ENDPOINT}
+  #  region_name: ${REGION_NAME}
+  #  access_key: ${ACCESS_KEY}
+  #  secret_key: ${SECRET_KEY}
+  bucket_name: ${BUCKET_NAME}
+#  image_folder_name: ${IMAGE_FOLDER_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     active: test
     include:
       - security
+      - storage
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
## 1. 주요 내용
- Event Domain에 빠진 필드가 있어서 추가
- Event Domain에 openAt, closeAt, isPeriod를 하나의 값타입으로 통합 ( EventDateTime.class )
- 참여할 이벤트 조회 API 구현 ( 미완성 )

## 2. 관련 문서 및 이슈
-  Event Domain을 수정했습니다. #6 
- #9 

## 3. 작업 내역 
- [x] Event Domain에 isPeriod 필드 추가
- [x] Event Domain에 openAt, closeAt, isPeriod를 하나의 값타입으로 통합
- [x] 참여할 이벤트 조회 API 구현
- [ ] 테스트 코드 작성

## 4. 참고 사항 
아직 미완성이지만 도메인쪽 수정사항이 발생하여 먼저 PR 보내봅니다.
도메인쪽 수정사항만 먼저 병합해야할것 같아서...
아직 테스트 코드 작성을 못하여 추가 개발진행 후 다시 PR을 보내겠습니다.

그리고 로그인쪽 관련하여 요청사항이 있는데
그건 금일 회의때 말씀드리겠습니다.


