### PR TITLE
feat: 이미지를 한번에 여러개를 업로드 할 수 있도록 수정한다 (#8)

### DIFF
--- a/src/main/java/com/nexters/pinataserver/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/ExceptionControllerAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.nexters.pinataserver.common.dto.response.CommonApiResponse;
 import com.nexters.pinataserver.common.exception.e4xx.AuthenticationException;
 import com.nexters.pinataserver.common.exception.e4xx.ExpiredAccessTokenException;
+import com.nexters.pinataserver.common.exception.e5xx.FileUploadException;
 import com.nexters.pinataserver.common.exception.e5xx.UnKnownException;
 
 import io.jsonwebtoken.JwtException;
@@ -38,6 +39,7 @@ public class ExceptionControllerAdvice {
 	}
 
 	@ExceptionHandler(ResponseException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public CommonApiResponse<ResponseException> processException(ResponseException exception) {
 		log.info("{}", exception);
 		return CommonApiResponse.error(exception);

--- a/src/main/java/com/nexters/pinataserver/common/exception/e5xx/FileUploadException.java
+++ b/src/main/java/com/nexters/pinataserver/common/exception/e5xx/FileUploadException.java
@@ -7,7 +7,8 @@ import com.nexters.pinataserver.common.exception.ResponseException;
 
 public enum FileUploadException implements ResponseDefinition {
 
-	IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "ERR5001", "이미지 업로드에 실패했습니다.");
+	IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "ERR5001", "이미지 업로드에 실패했습니다."),
+	IMAGE_FORMAT(HttpStatus.INTERNAL_SERVER_ERROR, "ERR5002", "잘못된 형식의 파일 입니다.");
 
 	private final ResponseException responseException;
 

--- a/src/main/java/com/nexters/pinataserver/common/image/ImageUploadController.java
+++ b/src/main/java/com/nexters/pinataserver/common/image/ImageUploadController.java
@@ -1,6 +1,7 @@
 package com.nexters.pinataserver.common.image;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -22,11 +23,11 @@ public class ImageUploadController {
 
 	@ResponseStatus(HttpStatus.OK)
 	@PostMapping("/api/v1/images")
-	public CommonApiResponse createBoards(@RequestParam(value = "files", required = false) MultipartFile multipartFile) throws
+	public CommonApiResponse createBoards(@RequestParam(value = "files", required = false) List<MultipartFile> multipartFile) throws
 		IOException {
-		String uploadedUrl = imageUploadService.upload(multipartFile);
+		List<String> uploadedUrls = imageUploadService.upload(multipartFile);
 
-		return CommonApiResponse.ok(ImageUploadResponse.of(uploadedUrl));
+		return CommonApiResponse.ok(ImageUploadResponse.of(uploadedUrls));
 	}
 
 }

--- a/src/main/java/com/nexters/pinataserver/common/image/ImageUploadResponse.java
+++ b/src/main/java/com/nexters/pinataserver/common/image/ImageUploadResponse.java
@@ -1,5 +1,7 @@
 package com.nexters.pinataserver.common.image;
 
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,11 +12,11 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageUploadResponse {
 
-	private String imageUrl;
+	private List<String> imageUrls;
 
-	public static ImageUploadResponse of(String imageUrl) {
+	public static ImageUploadResponse of(List<String> imageUrls) {
 		ImageUploadResponse imageUploadResponse = new ImageUploadResponse();
-		imageUploadResponse.setImageUrl(imageUrl);
+		imageUploadResponse.setImageUrls(imageUrls);
 
 		return imageUploadResponse;
 	}

--- a/src/main/java/com/nexters/pinataserver/common/image/ImageUploadService.java
+++ b/src/main/java/com/nexters/pinataserver/common/image/ImageUploadService.java
@@ -2,8 +2,14 @@ package com.nexters.pinataserver.common.image;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.nexters.pinataserver.common.exception.e5xx.FileUploadException;
+
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,16 +25,39 @@ public class ImageUploadService {
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;  // S3 버킷 이름
 
-    public String upload(MultipartFile multipartFile) throws IOException {
-        String fileName = new StringBuilder(UUID.randomUUID().toString())
-                .append("-")
-                .append(multipartFile.getOriginalFilename())
-                .toString();
+    public List<String> upload(List<MultipartFile> multipartFiles) {
 
-        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), null)
-                .withCannedAcl(CannedAccessControlList.PublicRead));
+        List<String> fileNameList = new ArrayList<>();
 
-        return amazonS3Client.getUrl(bucket, fileName).toString();
+        multipartFiles.forEach(file -> {
+            String fileName = createFileName(file.getOriginalFilename());
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            try(InputStream inputStream = file.getInputStream()) {
+                amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+            } catch(IOException e) {
+                throw FileUploadException.IMAGE.get();
+            }
+
+            fileNameList.add(fileName);
+        });
+
+        return fileNameList;
+    }
+
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw FileUploadException.IMAGE_FORMAT.get();
+        }
     }
 
 }


### PR DESCRIPTION
## 1. 주요 내용
- 이미지 업로드를 여러개의 파일을 한번에 할 수 있도록 수정합니다.

## 2. 관련 문서 및 이슈
- resolve #8

## 3. 작업 내역 
- [x] task 이미지 업로드를 여러개의 파일을 한번에 할 수 있도록 수정

## 4. 참고 사항 


