### PR TITLE
refactor: api prefix 싱크를 맞춘다 (#33)

### DIFF
--- a/src/main/java/com/nexters/pinataserver/auth/controller/AuthorizeController.java
+++ b/src/main/java/com/nexters/pinataserver/auth/controller/AuthorizeController.java
@@ -15,7 +15,7 @@ import com.nexters.pinataserver.user.domain.UserState;
 
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("/v1/auth")
+@RequestMapping("/api/v1/auth")
 @RestController
 @RequiredArgsConstructor
 public class AuthorizeController {

--- a/src/main/java/com/nexters/pinataserver/common/config/WebMvcConfig.java
+++ b/src/main/java/com/nexters/pinataserver/common/config/WebMvcConfig.java
@@ -26,8 +26,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(jwtInterceptor)
-			.addPathPatterns("/api/**")
-			.excludePathPatterns("/api/ping");
+			.addPathPatterns("/api/v1/**")
+			.excludePathPatterns("/api/v1/auth/signin");
 	}
 
 	@Override


### PR DESCRIPTION
## 1. 주요 내용
-  로그인과 나머지 api간에 prefix 싱크를 맞춘다

## 2. 관련 문서 및 이슈
- resolve #33

## 3. 작업 내역 
- [x] 로그인과 나머지 api간에 prefix 싱크를 맞춘다

## 4. 참고 사항 

