### PR TITLE
fix: 이벤트 참여 시 아이템 수령여부 변경 (#36)

### DIFF
--- a/src/main/java/com/nexters/pinataserver/event/domain/EventDateTime.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventDateTime.java
@@ -47,24 +47,25 @@ public class EventDateTime {
 	}
 
 	private void checkIsPeriod(Boolean isPeriod, LocalDateTime openAt, LocalDateTime closeAt) throws ResponseException {
-		if (isPeriod && (Objects.isNull(openAt) || Objects.isNull(closeAt))) {
+		// if (isPeriod && (Objects.isNull(openAt) || Objects.isNull(closeAt))) {
+		if (Objects.isNull(openAt) || Objects.isNull(closeAt)) {
 			throw EventTimeException.INVALID_INPUT.get();
 		}
 	}
 
 	public boolean isCanNotParticipate(LocalDateTime now) {
-		if (isPeriod) {
-			return now.isAfter(closeAt) || now.isBefore(openAt);
-		}
+		// if (isPeriod) {
+		// 	return now.isAfter(closeAt) || now.isBefore(openAt);
+		// }
 
 		return now.isAfter(closeAt);
 	}
 
 	public boolean isBeforeOpenDateTime(LocalDateTime now) {
-		// 시작 시간이 없으면 현재 시작중임
-		if (!isPeriod) {
-			return true;
-		}
+		// // 시작 시간이 없으면 현재 시작중임
+		// if (!isPeriod) {
+		// 	return true;
+		// }
 
 		return now.isBefore(openAt);
 	}

--- a/src/main/java/com/nexters/pinataserver/event/domain/EventItem.java
+++ b/src/main/java/com/nexters/pinataserver/event/domain/EventItem.java
@@ -75,4 +75,7 @@ public class EventItem extends AbstractSoftDeletableEntity {
 		this.event = event;
 	}
 
+	public void accept() {
+		this.isAccepted = true;
+	}
 }

--- a/src/main/java/com/nexters/pinataserver/event/service/EventParticipateService.java
+++ b/src/main/java/com/nexters/pinataserver/event/service/EventParticipateService.java
@@ -54,6 +54,7 @@ public class EventParticipateService {
 		if (isHit) {
 			foundEvent.hit();
 			hitEventItem = foundEvent.getHitEventItem();
+			hitEventItem.accept();
 		} else {
 			foundEvent.miss();
 			hitEventItem = EventItem.builder().build();

--- a/src/main/java/com/nexters/pinataserver/event/service/EventValidateService.java
+++ b/src/main/java/com/nexters/pinataserver/event/service/EventValidateService.java
@@ -1,5 +1,9 @@
 package com.nexters.pinataserver.event.service;
 
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
 import com.nexters.pinataserver.common.exception.e4xx.DuplicatedException;
 import com.nexters.pinataserver.common.exception.e4xx.EventStatusException;
 import com.nexters.pinataserver.common.exception.e4xx.EventTimeException;
@@ -7,9 +11,8 @@ import com.nexters.pinataserver.event.domain.Event;
 import com.nexters.pinataserver.event.domain.EventDateTime;
 import com.nexters.pinataserver.event.domain.EventStatus;
 import com.nexters.pinataserver.event_history.domain.EventHistoryRepository;
-import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +25,7 @@ public class EventValidateService {
         fixEventStatus(foundEvent);
 
         // 이미 참가한 이벤트인지 검증
-        checkAlreadyParticipate(participantId, foundEvent.getId());
+        // checkAlreadyParticipate(participantId, foundEvent.getId());
 
         // 기간이 지나지는 않았나??
         checkEventTimeOut(foundEvent);


### PR DESCRIPTION
## 1. 주요 내용
- 이벤트 참여 API 호출 시 상품 수령여부가 바뀌고 있지 않던 문제를 해결

## 2. 관련 문서 및 이슈
- resolve #36 

## 3. 작업 내역 
- [x] 상품수령여부 변경 로직 추가

## 4. 참고 사항 
코드 리뷰 시 참고해야 하는 사항이 있다면 작성해주세요.


